### PR TITLE
Abstract parsing of TEST_KBC_PROJECTS to reusable function (KAC-153 KAC-180)

### DIFF
--- a/pkg/testproject/testproject.go
+++ b/pkg/testproject/testproject.go
@@ -74,8 +74,8 @@ func GetTestProject(t *testing.T) *Project {
 	}
 }
 
-// GetRandomTestProject returns a random testing project specified in TEST_KBC_PROJECTS environment variable.
-func GetRandomTestProject() *ProjectDef {
+// GetRandomTestProjectDef returns a random testing project definition specified in TEST_KBC_PROJECTS environment variable.
+func GetRandomTestProjectDef() *ProjectDef {
 	defs := parseProjects()
 	return defs[rand.Intn(len(defs))]
 }

--- a/pkg/testproject/testproject_test.go
+++ b/pkg/testproject/testproject_test.go
@@ -43,3 +43,14 @@ func TestGetTestProject_Empty(t *testing.T) {
 		_ = testproject.GetTestProject(t)
 	})
 }
+
+func TestGetRandomTestProject(t *testing.T) {
+	def1 := "connection.keboola.com|1234|1234-abcdef;"
+	def2 := "connection.keboola.com|3456|3456-abcdef;"
+	def3 := "connection.keboola.com|5678|5678-abcdef;"
+	_ = os.Setenv("TEST_KBC_PROJECTS", def1+def2+def3)
+
+	def := testproject.GetRandomTestProject()
+	assert.IsType(t, &testproject.ProjectDef{}, def)
+	assert.Equal(t, "connection.keboola.com", def.StorageAPIHost)
+}

--- a/pkg/testproject/testproject_test.go
+++ b/pkg/testproject/testproject_test.go
@@ -50,7 +50,7 @@ func TestGetRandomTestProject(t *testing.T) {
 	def3 := "connection.keboola.com|5678|5678-abcdef;"
 	_ = os.Setenv("TEST_KBC_PROJECTS", def1+def2+def3)
 
-	def := testproject.GetRandomTestProject()
+	def := testproject.GetRandomTestProjectDef()
 	assert.IsType(t, &testproject.ProjectDef{}, def)
 	assert.Equal(t, "connection.keboola.com", def.StorageAPIHost)
 }


### PR DESCRIPTION
Potřebuju volat `GetTestProject()` zvenku bez `testing.T` a nepotřebuju zamykání, tak přidávám `GetRandomTestProject()`.