### PR TITLE
orderedmap: fix UnmarshalYAML, check node tag

### DIFF
--- a/pkg/orderedmap/yaml.go
+++ b/pkg/orderedmap/yaml.go
@@ -35,6 +35,11 @@ func (o *OrderedMap) UnmarshalYAML(node *yaml.Node) error {
 		o.values = map[string]any{}
 	}
 
+	// Check node type
+	if node.Tag != "!!map" {
+		return fmt.Errorf("cannot unmarshal %s `%s` into orderedmap", node.Tag, node.Value)
+	}
+
 	// Iterate nodes: key1, value1, key2, value2, ...
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]

--- a/pkg/orderedmap/yaml_test.go
+++ b/pkg/orderedmap/yaml_test.go
@@ -361,3 +361,10 @@ func TestOrderedMap_UnmarshalYAML_Struct(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, value)
 }
+
+func TestOrderedMap_UnmarshalYAML_Text(t *testing.T) {
+	o := New()
+	err := yaml.Unmarshal([]byte("some text"), o)
+	assert.Error(t, err)
+	assert.Equal(t, "cannot unmarshal !!str `some text` into orderedmap", err.Error())
+}


### PR DESCRIPTION
Changes:
- UnmarshalYAML checks `node.tag`, for example a string cannot be decoded to orderedmap.