### PR TITLE
Add bool result to wildcards.Assert func

### DIFF
--- a/pkg/wildcards/wildcards.go
+++ b/pkg/wildcards/wildcards.go
@@ -61,11 +61,13 @@ func Compare(expected string, actual string) error {
 }
 
 // Assert compares two texts and allows using wildcards in expected value, see ToRegexp function.
-func Assert(t assert.TestingT, expected string, actual string, msgAndArgs ...any) {
+func Assert(t assert.TestingT, expected string, actual string, msgAndArgs ...any) bool {
 	err := Compare(expected, actual)
 	if err != nil {
 		assert.Fail(t, err.Error(), msgAndArgs...)
+		return false
 	}
+	return true
 }
 
 // ToRegexp converts string with wildcards to regexp, so it can be used in assert.Regexp.

--- a/pkg/wildcards/wildcards_test.go
+++ b/pkg/wildcards/wildcards_test.go
@@ -26,21 +26,24 @@ func (t *mockedT) Errorf(format string, args ...any) {
 func TestAssertWildcardsSame1(t *testing.T) {
 	t.Parallel()
 	test := &mockedT{buf: bytes.NewBuffer(nil)}
-	Assert(test, "foo", "foo", "Fail msg.")
+	ok := Assert(test, "foo", "foo", "Fail msg.")
+	assert.True(t, ok)
 	assert.Equal(t, "", test.buf.String())
 }
 
 func TestAssertWildcardsSame2(t *testing.T) {
 	t.Parallel()
 	test := &mockedT{buf: bytes.NewBuffer(nil)}
-	Assert(test, "%c%c%c", "foo", "Fail msg.")
+	ok := Assert(test, "%c%c%c", "foo", "Fail msg.")
+	assert.True(t, ok)
 	assert.Equal(t, "", test.buf.String())
 }
 
 func TestAssertWildcardsDifferent1(t *testing.T) {
 	t.Parallel()
 	test := &mockedT{buf: bytes.NewBuffer(nil)}
-	Assert(test, "foo", "bar")
+	ok := Assert(test, "foo", "bar")
+	assert.False(t, ok)
 	expected := `
 Diff:
 -----
@@ -68,7 +71,8 @@ foo
 func TestAssertWildcardsDifferent2(t *testing.T) {
 	t.Parallel()
 	test := &mockedT{buf: bytes.NewBuffer(nil)}
-	Assert(test, "%c%c%c%c", "bar")
+	ok := Assert(test, "%c%c%c%c", "bar")
+	assert.False(t, ok)
 	expected := `
 Diff:
 -----
@@ -148,7 +152,8 @@ Foo7: bar7
 -----
 `
 
-	Assert(test, wildcards, actual)
+	ok := Assert(test, wildcards, actual)
+	assert.False(t, ok)
 	// Get error message
 	_, testLog, _ := strings.Cut(test.buf.String(), "Error:")
 	// Trim leading whitespaces from each line


### PR DESCRIPTION
Changes:
- Added bool return value to the `wildcards.Assert` function:
  - `true` means that values are equal, ... same logic as in the `assert.Equal` func.