### PR TITLE
Orderedmap: Improve YAML marshaling, value can by *yaml.Node

### DIFF
--- a/pkg/orderedmap/yaml.go
+++ b/pkg/orderedmap/yaml.go
@@ -9,27 +9,26 @@ import (
 func (o *OrderedMap) MarshalYAML() (any, error) {
 	node := &yaml.Node{Kind: yaml.MappingNode}
 	for _, key := range o.Keys() {
-		value, _ := o.Get(key)
-
 		// Encode key
 		keyNode := &yaml.Node{Kind: yaml.MappingNode}
-		node.Content = append(node.Content, keyNode)
 		if err := keyNode.Encode(key); err != nil {
 			return nil, err
 		}
 
 		// Encode value
-		var valueNode *yaml.Node
-		if v, ok := value.(*yaml.Node); ok {
-			valueNode = v
-		} else {
-			valueNode = &yaml.Node{Kind: yaml.ScalarNode}
-			if err := valueNode.Encode(value); err != nil {
-				return nil, err
-			}
+		value, _ := o.Get(key)
+		valueNode, err := encodeYamlValue(value)
+		if err != nil {
+			return nil, err
 		}
 
-		node.Content = append(node.Content, valueNode)
+		// Move head comment from the value to the key node, if any
+		if valueNode.HeadComment != "" {
+			keyNode.HeadComment = valueNode.HeadComment
+			valueNode.HeadComment = ""
+		}
+
+		node.Content = append(node.Content, keyNode, valueNode)
 	}
 
 	return node, nil
@@ -72,6 +71,35 @@ func (o *OrderedMap) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	return nil
+}
+
+func encodeYamlValue(value any) (out *yaml.Node, err error) {
+	switch v := value.(type) {
+	case *yaml.Node:
+		return v, nil
+	case *OrderedMap:
+		if subNode, err := v.MarshalYAML(); err == nil {
+			return subNode.(*yaml.Node), nil
+		} else {
+			return nil, err
+		}
+	case []any:
+		out = &yaml.Node{Kind: yaml.SequenceNode}
+		for _, item := range v {
+			if subNode, err := encodeYamlValue(item); err == nil {
+				out.Content = append(out.Content, subNode)
+			} else {
+				return nil, err
+			}
+		}
+		return out, nil
+	default:
+		out = &yaml.Node{Kind: yaml.ScalarNode}
+		if err := out.Encode(value); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
 }
 
 func decodeYamlValue(node *yaml.Node, out *any) error {

--- a/pkg/orderedmap/yaml.go
+++ b/pkg/orderedmap/yaml.go
@@ -19,12 +19,17 @@ func (o *OrderedMap) MarshalYAML() (any, error) {
 		}
 
 		// Encode value
-		valueNode := &yaml.Node{Kind: yaml.ScalarNode}
-		node.Content = append(node.Content, valueNode)
-		err := valueNode.Encode(value)
-		if err != nil {
-			return nil, err
+		var valueNode *yaml.Node
+		if v, ok := value.(*yaml.Node); ok {
+			valueNode = v
+		} else {
+			valueNode = &yaml.Node{Kind: yaml.ScalarNode}
+			if err := valueNode.Encode(value); err != nil {
+				return nil, err
+			}
 		}
+
+		node.Content = append(node.Content, valueNode)
 	}
 
 	return node, nil

--- a/pkg/orderedmap/yaml_test.go
+++ b/pkg/orderedmap/yaml_test.go
@@ -23,7 +23,7 @@ func TestOrderedMap_MarshalYAML(t *testing.T) {
 	o.Set("number", 4)
 	// keys not sorted alphabetically
 	o.Set("z", 1)
-	o.Set("a", 2)
+	o.Set("a", &yaml.Node{Kind: yaml.ScalarNode, Value: "2", LineComment: "my comment"})
 	o.Set("b", 3)
 	// slice
 	o.Set("slice", []any{
@@ -44,7 +44,7 @@ number: 4
 string: x
 specialstring: \.<>[]{}_-
 z: 1
-a: 2
+a: 2 # my comment
 b: 3
 slice:
   - "1"

--- a/pkg/orderedmap/yaml_test.go
+++ b/pkg/orderedmap/yaml_test.go
@@ -23,17 +23,17 @@ func TestOrderedMap_MarshalYAML(t *testing.T) {
 	o.Set("number", 4)
 	// keys not sorted alphabetically
 	o.Set("z", 1)
-	o.Set("a", &yaml.Node{Kind: yaml.ScalarNode, Value: "2", LineComment: "my comment"})
+	o.Set("a", &yaml.Node{Kind: yaml.ScalarNode, Value: "2", LineComment: "line comment"})
 	o.Set("b", 3)
 	// slice
 	o.Set("slice", []any{
-		"1",
-		1,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "1", Style: yaml.DoubleQuotedStyle, HeadComment: "head comment"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "1", LineComment: "line comment"},
 	})
 	// orderedmap
 	v := New()
-	v.Set("e", 1)
-	v.Set("a", 2)
+	v.Set("e", &yaml.Node{Kind: yaml.ScalarNode, Value: "1", LineComment: "line comment"})
+	v.Set("a", &yaml.Node{Kind: yaml.ScalarNode, Value: "2", HeadComment: "head comment"})
 	o.Set("orderedmap", v)
 	// escape key
 	o.Set("test\n\r\t\\\"ing", 9)
@@ -44,13 +44,15 @@ number: 4
 string: x
 specialstring: \.<>[]{}_-
 z: 1
-a: 2 # my comment
+a: 2 # line comment
 b: 3
 slice:
+  # head comment
   - "1"
-  - 1
+  - 1 # line comment
 orderedmap:
-  e: 1
+  e: 1 # line comment
+  # head comment
   a: 2
 ? "test\n\r\t\\\"ing"
 : 9

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -10,5 +10,5 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"
 
 ./install-gotestsum.sh -b $(go env GOPATH)/bin
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@master
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 go install golang.org/x/tools/cmd/godoc@latest


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PSGO-286

Changes:
- If a value in the `orderedmap` is `*yaml.Node`, then it is directry used by YAML encoder.