### PR TITLE
ci: update GitHub actions with redis lock

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,9 @@ jobs:
           make tools
 
       - name: Lint and test
+        env: 
+          TEST_KBC_PROJECTS_LOCK_HOST: ${{ secrets.TEST_KBC_PROJECTS_LOCK_HOST }}
+          TEST_KBC_PROJECTS_LOCK_PASSWORD: ${{ secrets.TEST_KBC_PROJECTS_LOCK_PASSWORD }}
         run: |
           make lint
           make tests


### PR DESCRIPTION
Jira: 
- [PSGO-528](https://keboola.atlassian.net/browse/PSGO-528)

**Changes:**
- Update github actions workflow to support new redis locks.

-----------

[PSGO-528]: https://keboola.atlassian.net/browse/PSGO-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ