### PR TITLE
fix: Unlock using context cancel instead of background context

### DIFF
--- a/pkg/testproject/redislocker.go
+++ b/pkg/testproject/redislocker.go
@@ -132,6 +132,12 @@ func (rl *redisProjectLocker) unlock() {
 	if err := rl.redisLock.Release(context.Background()); err != nil {
 		panic(fmt.Errorf(`cannot unlock test project using redis lock: %w`, err))
 	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if rl.cancel != nil {
+		rl.cancel()
+	}
 }
 
 func (rl *redisProjectLocker) isLocked() bool {

--- a/pkg/testproject/testproject.go
+++ b/pkg/testproject/testproject.go
@@ -191,7 +191,7 @@ func GetTestProject(opts ...Option) (*Project, context.CancelFunc, error) {
 	return mustGetProjects().GetTestProject(opts...)
 }
 
-func GetTestProjectInPath(path string, opts ...Option) (*Project, UnlockFn, error) {
+func GetTestProjectInPath(path string, opts ...Option) (*Project, context.CancelFunc, error) {
 	return mustGetProjectsInPath(path).GetTestProject(opts...)
 }
 


### PR DESCRIPTION
**Changes**
* Rework cancelation of locks using `context.CancelFunc` as it is the same as `UnlockFn`.