### PR TITLE
fix: Show message when TEST_KBC_PROJECTS_FILE is not set.

### DIFF
--- a/pkg/testproject/testproject.go
+++ b/pkg/testproject/testproject.go
@@ -377,10 +377,13 @@ func getProjects(path string) (*ProjectsPool, error) {
 	projectsFile := path
 	if projectsFile == "" {
 		projectsFile = os.Getenv(TestKbcProjectsFileKey) // nolint: forbidigo
+		if projectsFile == "" {
+			return nil, fmt.Errorf("please set TEST_KBC_PROJECTS_FILE environment variable")
+		}
 	}
 
 	if !filepath.IsAbs(projectsFile) {
-		return nil, fmt.Errorf("the projects file should be absolute, not relative, got %s", projectsFile)
+		return nil, fmt.Errorf("the path to projects.json file should be absolute, not relative, got %s", projectsFile)
 	}
 
 	// Init projects from the json projects file


### PR DESCRIPTION
Add new message when projects.json is not set properly.