### PR TITLE
feat: Add DeleteFunc

### DIFF
--- a/pkg/orderedmap/orderedmap.go
+++ b/pkg/orderedmap/orderedmap.go
@@ -322,6 +322,18 @@ func (o *OrderedMap) Delete(key string) {
 	delete(o.values, key)
 }
 
+func (o *OrderedMap) DeleteFunc(fn func(key string) bool) {
+	toDelete := []string{}
+	for _, key := range o.keys {
+		if fn(key) {
+			toDelete = append(toDelete, key)
+		}
+	}
+	for _, key := range toDelete {
+		o.Delete(key)
+	}
+}
+
 // Len returns number of keys.
 func (o *OrderedMap) Len() int {
 	return len(o.keys)

--- a/pkg/orderedmap/orderedmap_test.go
+++ b/pkg/orderedmap/orderedmap_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOrderedMap(t *testing.T) {
@@ -534,4 +535,22 @@ path=str, parent=*orderedmap.OrderedMap, value=string
 		visited = append(visited, fmt.Sprintf(`path=%s, parent=%T, value=%T`, path, parent, value))
 	})
 	assert.Equal(t, strings.TrimSpace(expected), strings.Join(visited, "\n"))
+}
+
+func TestOrderedMap_DeleteFunc(t *testing.T) {
+	t.Parallel()
+	o := New()
+
+	o.Set("a", true)
+	o.DeleteFunc(func(key string) bool {
+		return strings.HasPrefix("a/b", key+"/")
+	})
+	o.Set("a/c", true)
+	o.Set("a/c/d", true)
+	o.Set("a/c/d/e", true)
+	o.DeleteFunc(func(key string) bool {
+		return strings.HasPrefix("a/c/d/e/f", key+"/")
+	})
+
+	require.Len(t, o.Keys(), 0)
 }


### PR DESCRIPTION
The new `orderedmap.Delete` implementation was causing an issue here: https://github.com/keboola/keboola-as-code/blob/9131dd8107983377cdd44d5bfbd7ad141707c6b4/internal/pkg/state/local/delete.go#L57-L61

It's however not a problem with go-utils or slices, rather the usage of Delete while the slice is being iterated is the core problem.

To fix this I'm introducing a new method `DeleteFunc` (similar to `slices.DeleteFunc`),

I'm also fixing `Keys` to return a new copy.