### PR TITLE
fix: Array unmarshalling does not work properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1
+FROM golang:1.24.6
 
 ENV HOME=/my-home
 ENV GOCACHE=/tmp/cache/go


### PR DESCRIPTION
**Changes:**
- It is reported as map[string]interface{} instead of []string
- Reported [here ](https://keboolaglobal.slack.com/archives/C0570JS4CBA/p1757673167328899), done analysis with Odin

-----------
