### PR TITLE
chore(PSGO-38): bump Go directive from 1.24.1 to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6
+FROM golang:1.26.3
 
 ENV HOME=/my-home
 ENV GOCACHE=/tmp/cache/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keboola/go-utils
 
-go 1.24.1
+go 1.26.3
 
 require (
 	github.com/bsm/redislock v0.9.4

--- a/pkg/orderedmap/json.go
+++ b/pkg/orderedmap/json.go
@@ -128,7 +128,7 @@ func decodeJsonSlice(dec *json.Decoder, s []any) error {
 			switch delim {
 			case '{':
 				if index < len(s) {
-					if values, ok := s[index].(map[string]any); ok {
+					if values, ok := s[index].(map[string]any); ok { // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
 						newMap := &OrderedMap{
 							keys:   make([]string, 0, len(values)),
 							values: values,
@@ -136,8 +136,8 @@ func decodeJsonSlice(dec *json.Decoder, s []any) error {
 						if err = decodeJsonOrderedMap(dec, newMap); err != nil {
 							return err
 						}
-						s[index] = newMap
-					} else if oldMap, ok := s[index].(*OrderedMap); ok {
+						s[index] = newMap // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
+					} else if oldMap, ok := s[index].(*OrderedMap); ok { // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
 						newMap := &OrderedMap{
 							keys:   make([]string, 0, len(oldMap.values)),
 							values: oldMap.values,
@@ -145,7 +145,7 @@ func decodeJsonSlice(dec *json.Decoder, s []any) error {
 						if err = decodeJsonOrderedMap(dec, newMap); err != nil {
 							return err
 						}
-						s[index] = newMap
+						s[index] = newMap // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
 					} else if err = decodeJsonOrderedMap(dec, &OrderedMap{}); err != nil {
 						return err
 					}
@@ -154,12 +154,12 @@ func decodeJsonSlice(dec *json.Decoder, s []any) error {
 				}
 			case '[':
 				if index < len(s) {
-					if values, ok := s[index].([]any); ok {
+					if values, ok := s[index].([]any); ok { // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
 						if err = decodeJsonSlice(dec, values); err != nil {
 							return err
 						}
 						// convert nested []any of strings to []string
-						s[index] = convertStringSliceIfPossible(values)
+						s[index] = convertStringSliceIfPossible(values) // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
 					} else if err = decodeJsonSlice(dec, []any{}); err != nil {
 						return err
 					}

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"
 
 # Version to install
-GOLANGCI_LINT_VERSION="v2.0.2"
+GOLANGCI_LINT_VERSION="v2.9.0"
 
 # golangci-lint
 if ! command -v golangci-lint &> /dev/null


### PR DESCRIPTION
Jira: https://linear.app/keboola/issue/PSGO-38/update-golang-version-in-go-utils

**Changes:**
- Bump `go.mod` directive from `go 1.24.1` to `go 1.26.3`
- Bump `Dockerfile` base image from `golang:1.24.6` to `golang:1.26.3`
- Bump pinned `golangci-lint` in `scripts/tools.sh` from `v2.0.2` to `v2.9.0` - required, not optional: v2.0.2 was built with go1.24 and refuses to lint a module targeting go 1.26.3. v2.9.0 is the earliest release built with go1.26, chosen to minimize drift from v2.0.2's accepted baseline.
- Add 6 justified `nolint:gosec` (G602) suppressions in `pkg/orderedmap/json.go`'s pre-existing `decodeJsonSlice` - the newer gosec bundled in v2.9.0 false-positives on `s[index]` accesses already guarded by an `index < len(s)` check one line up.

No other changes. This is deliberately split from the `orderedmap` JSON-decoding fix (PSGO-37, #72) so the two can be reviewed and rolled back independently — this one is pure version-directive/tooling, no behavioral change:
- `OrderedMap` orders keys via its own `[]string` slice, independent of Go's internal map implementation, so Go 1.24's swiss-table map rewrite has no bearing on ordering here.
- Both downstream consumers (`keboola-sdk-go`, `keboola-as-code`) already build against `go 1.26.3` — this only catches go-utils' own `go.mod`/`Dockerfile` up to match what's already true in practice.

Verified: `go build ./...`, `go vet ./...`, `task tests` (62 tests, 1 pre-existing skip for missing Redis credentials, unrelated), and `golangci-lint run` using the v2.9.0 binary - all clean. CI initially failed on this exact golangci-lint incompatibility; fixed in the second commit.

-----------