### PR TITLE
fix(PSGO-37): stop OrderedMap guessing []string from array contents

### DIFF
--- a/pkg/orderedmap/convert.go
+++ b/pkg/orderedmap/convert.go
@@ -1,0 +1,37 @@
+package orderedmap
+
+import (
+	"fmt"
+	"slices"
+)
+
+// ToStringSlice converts a value obtained from OrderedMap (e.g. via Get or GetNested) into a
+// []string. OrderedMap itself never guesses a field's schema from its runtime content - JSON/YAML
+// arrays always decode to []any - so callers that know a specific field is a string array must
+// opt in explicitly via this helper. Accepts either []any (the JSON/YAML-decoded shape) or
+// []string directly (e.g. a value set programmatically via Set).
+//
+// A nil value is an error, not an empty slice: nil is what GetNestedOrNil returns for a missing
+// path, and treating it as "no error, empty result" would recreate the exact silent-no-op this
+// helper exists to prevent. Callers must check Get/GetNested's found return first.
+func ToStringSlice(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		// Clone: the []any branch below always returns a fresh slice, so callers must be able to
+		// mutate the result without risk regardless of which branch produced it. Without this,
+		// mutating the result of a []string-backed value would alias and mutate the OrderedMap.
+		return slices.Clone(v), nil
+	case []any:
+		out := make([]string, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf(`expected string at index %d, found "%T"`, i, item)
+			}
+			out[i] = s
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf(`expected []any or []string, found "%T"`, value)
+	}
+}

--- a/pkg/orderedmap/json.go
+++ b/pkg/orderedmap/json.go
@@ -103,15 +103,8 @@ func decodeJsonOrderedMap(dec *json.Decoder, o *OrderedMap) error {
 					if err = decodeJsonSlice(dec, values); err != nil {
 						return err
 					}
-					// convert []any of strings to []string
-					o.values[key] = convertStringSliceIfPossible(o.values[key])
 				} else if err = decodeJsonSlice(dec, []any{}); err != nil {
 					return err
-				} else {
-					// ensure conversion even if initial type hint was empty []any
-					if v, ok := o.values[key].([]any); ok {
-						o.values[key] = convertStringSliceIfPossible(v)
-					}
 				}
 			}
 		}
@@ -158,8 +151,6 @@ func decodeJsonSlice(dec *json.Decoder, s []any) error {
 						if err = decodeJsonSlice(dec, values); err != nil {
 							return err
 						}
-						// convert nested []any of strings to []string
-						s[index] = convertStringSliceIfPossible(values) // nolint:gosec // G602: index is bounds-checked by "index < len(s)" above
 					} else if err = decodeJsonSlice(dec, []any{}); err != nil {
 						return err
 					}
@@ -171,35 +162,4 @@ func decodeJsonSlice(dec *json.Decoder, s []any) error {
 			}
 		}
 	}
-}
-
-// convertStringSliceIfPossible turns []any where all elements are strings into []string recursively.
-func convertStringSliceIfPossible(v any) any {
-	arr, ok := v.([]any)
-	if !ok {
-		return v
-	}
-	outStr := make([]string, len(arr))
-	for i, el := range arr {
-		switch t := el.(type) {
-		case string:
-			outStr[i] = t
-		default:
-			return convertNestedSlices(arr)
-		}
-	}
-	return outStr
-}
-
-func convertNestedSlices(arr []any) []any {
-	out := make([]any, len(arr))
-	for i, el := range arr {
-		// Recurse for nested []any
-		if sub, ok := el.([]any); ok {
-			out[i] = convertStringSliceIfPossible(sub)
-			continue
-		}
-		out[i] = el
-	}
-	return out
 }

--- a/pkg/orderedmap/json_test.go
+++ b/pkg/orderedmap/json_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOrderedMap_MarshalJSON(t *testing.T) {
@@ -373,31 +374,27 @@ func TestOrderedMap_UnmarshalJSON_ArrayOfStrings_StaysAny(t *testing.T) {
 	t.Parallel()
 	in := `{"rowsSortOrder":["a","b","c"]}`
 	m := New()
-	assert.NoError(t, json.Unmarshal([]byte(in), &m))
+	require.NoError(t, json.Unmarshal([]byte(in), &m))
 	v, ok := m.Get("rowsSortOrder")
-	assert.True(t, ok)
+	require.True(t, ok)
 	arr, ok := v.([]any)
-	assert.True(t, ok, "expected []any, got %T", v)
+	require.True(t, ok, "expected []any, got %T", v)
 	assert.Equal(t, []any{"a", "b", "c"}, arr)
-
-	ss, err := ToStringSlice(v)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"a", "b", "c"}, ss)
 }
 
 func TestOrderedMap_UnmarshalJSON_NestedArrayOfStrings_StaysAny(t *testing.T) {
 	t.Parallel()
 	in := `{"arr":[["a","b"],["c"]]}`
 	m := New()
-	assert.NoError(t, json.Unmarshal([]byte(in), &m))
+	require.NoError(t, json.Unmarshal([]byte(in), &m))
 	v, _ := m.Get("arr")
 	outer, ok := v.([]any)
-	assert.True(t, ok)
+	require.True(t, ok, "expected []any, got %T", v)
 	inner0, ok := outer[0].([]any)
-	assert.True(t, ok, "expected []any, got %T", outer[0])
+	require.True(t, ok, "expected []any, got %T", outer[0])
 	assert.Equal(t, []any{"a", "b"}, inner0)
 	inner1, ok := outer[1].([]any)
-	assert.True(t, ok, "expected []any, got %T", outer[1])
+	require.True(t, ok, "expected []any, got %T", outer[1])
 	assert.Equal(t, []any{"c"}, inner1)
 }
 
@@ -408,37 +405,90 @@ func TestOrderedMap_UnmarshalJSON_EmptyArray_StaysAny(t *testing.T) {
 	t.Parallel()
 	in := `{"arr":[]}`
 	m := New()
-	assert.NoError(t, json.Unmarshal([]byte(in), &m))
+	require.NoError(t, json.Unmarshal([]byte(in), &m))
 	v, ok := m.Get("arr")
-	assert.True(t, ok)
+	require.True(t, ok)
 	arr, ok := v.([]any)
-	assert.True(t, ok, "expected []any, got %T", v)
+	require.True(t, ok, "expected []any, got %T", v)
 	assert.Empty(t, arr)
+}
+
+// Regression test for the v1.4.1 breakage: it wasn't only external consumers that broke.
+// OrderedMap's own path-based accessors (SetNestedPath/GetNestedPath's SliceStep handling,
+// VisitAllRecursive) type-switch on []any internally - once a decoded string array became
+// []string, GetNested/SetNested on an index into it returned "expected array found []string",
+// and VisitAllRecursive never descended into it at all. This documents why the type matters at
+// the package's own API surface, independent of any downstream consumer.
+func TestOrderedMap_DecodedStringArray_PathAccessors(t *testing.T) {
+	t.Parallel()
+	in := `{"dependsOn":["a","b"]}`
+	m := New()
+	require.NoError(t, json.Unmarshal([]byte(in), &m))
+
+	value, found, err := m.GetNested("dependsOn[0]")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "a", value)
+
+	require.NoError(t, m.SetNested("dependsOn[1]", "z"))
+	value, found, err = m.GetNested("dependsOn[1]")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "z", value)
+
+	var visited []string
+	m.VisitAllRecursive(func(path Path, _ any, _ any) {
+		visited = append(visited, path.String())
+	})
+	assert.Contains(t, visited, "dependsOn[0]")
+	assert.Contains(t, visited, "dependsOn[1]")
 }
 
 func TestToStringSlice(t *testing.T) {
 	t.Parallel()
+	cases := []struct {
+		name   string
+		input  any
+		output []string
+		err    string
+	}{
+		{name: "empty []any", input: []any{}, output: []string{}},
+		{name: "[]any of strings", input: []any{"a", "b"}, output: []string{"a", "b"}},
+		{name: "already-typed []string", input: []string{"a", "b"}, output: []string{"a", "b"}},
+		{name: "nil is an error, not an empty result", input: nil, err: `expected []any or []string, found "<nil>"`},
+		{name: "wrong type", input: "not a slice", err: `expected []any or []string, found "string"`},
+		{name: "non-string element", input: []any{"a", 1}, err: `expected string at index 1, found "int"`},
+	}
 
-	ss, err := ToStringSlice(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{}, ss)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := ToStringSlice(c.input)
+			if c.err == "" {
+				require.NoError(t, err)
+				assert.Equal(t, c.output, actual)
+			} else {
+				require.Error(t, err)
+				assert.EqualError(t, err, c.err)
+			}
+		})
+	}
+}
 
-	ss, err = ToStringSlice([]any{})
-	assert.NoError(t, err)
-	assert.Equal(t, []string{}, ss)
+// Regression test for the aliasing bug: the []string branch must not return the caller's backing
+// array, or mutating the result would silently mutate the value stored inside the OrderedMap.
+func TestToStringSlice_DoesNotAliasStringInput(t *testing.T) {
+	t.Parallel()
+	m := New()
+	original := []string{"a", "b"}
+	m.Set("key", original)
 
-	ss, err = ToStringSlice([]any{"a", "b"})
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"a", "b"}, ss)
+	value, _ := m.Get("key")
+	result, err := ToStringSlice(value)
+	require.NoError(t, err)
+	result[0] = "mutated"
 
-	// Already-typed []string (e.g. set programmatically via Set) is accepted as-is.
-	ss, err = ToStringSlice([]string{"a", "b"})
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"a", "b"}, ss)
-
-	_, err = ToStringSlice("not a slice")
-	assert.ErrorContains(t, err, `expected []any or []string, found "string"`)
-
-	_, err = ToStringSlice([]any{"a", 1})
-	assert.ErrorContains(t, err, `expected string at index 1, found "int"`)
+	stillOriginal, _ := m.Get("key")
+	assert.Equal(t, []string{"a", "b"}, stillOriginal)
+	assert.Equal(t, []string{"a", "b"}, original)
 }

--- a/pkg/orderedmap/json_test.go
+++ b/pkg/orderedmap/json_test.go
@@ -363,21 +363,29 @@ func TestOrderedMap_UnmarshalJSON_Struct(t *testing.T) {
 	assert.Equal(t, float64(1), value)
 }
 
-func TestOrderedMap_UnmarshalJSON_StringSlice(t *testing.T) {
+// An array of strings decodes to []any like any other JSON array - OrderedMap does not guess a
+// field's schema from its runtime content. Callers that know a field is a string array convert
+// explicitly via ToStringSlice (see TestToStringSlice). This guards against reintroducing the
+// value-dependent []any->[]string coercion removed in PSGO-37: that coercion broke every existing
+// `.([]any)` assertion for a string-only array anywhere in a decoded document (orchestrator
+// `dependsOn`, `shared_code_row_ids`, JSON-Schema `required`, etc. in keboola-as-code).
+func TestOrderedMap_UnmarshalJSON_ArrayOfStrings_StaysAny(t *testing.T) {
 	t.Parallel()
 	in := `{"rowsSortOrder":["a","b","c"]}`
 	m := New()
 	assert.NoError(t, json.Unmarshal([]byte(in), &m))
 	v, ok := m.Get("rowsSortOrder")
 	assert.True(t, ok)
-	_, isAny := v.([]any)
-	assert.False(t, isAny)
-	ss, ok := v.([]string)
-	assert.True(t, ok)
+	arr, ok := v.([]any)
+	assert.True(t, ok, "expected []any, got %T", v)
+	assert.Equal(t, []any{"a", "b", "c"}, arr)
+
+	ss, err := ToStringSlice(v)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"a", "b", "c"}, ss)
 }
 
-func TestOrderedMap_UnmarshalJSON_NestedStringSlice(t *testing.T) {
+func TestOrderedMap_UnmarshalJSON_NestedArrayOfStrings_StaysAny(t *testing.T) {
 	t.Parallel()
 	in := `{"arr":[["a","b"],["c"]]}`
 	m := New()
@@ -385,10 +393,52 @@ func TestOrderedMap_UnmarshalJSON_NestedStringSlice(t *testing.T) {
 	v, _ := m.Get("arr")
 	outer, ok := v.([]any)
 	assert.True(t, ok)
-	inner0, ok := outer[0].([]string)
+	inner0, ok := outer[0].([]any)
+	assert.True(t, ok, "expected []any, got %T", outer[0])
+	assert.Equal(t, []any{"a", "b"}, inner0)
+	inner1, ok := outer[1].([]any)
+	assert.True(t, ok, "expected []any, got %T", outer[1])
+	assert.Equal(t, []any{"c"}, inner1)
+}
+
+// Regression test: an empty array must stay []any{}, not be silently coerced to []string{}.
+// The removed coercion converted every empty array unconditionally, regardless of the field's
+// true schema (e.g. an empty "rows": [] array of objects would have become []string{}).
+func TestOrderedMap_UnmarshalJSON_EmptyArray_StaysAny(t *testing.T) {
+	t.Parallel()
+	in := `{"arr":[]}`
+	m := New()
+	assert.NoError(t, json.Unmarshal([]byte(in), &m))
+	v, ok := m.Get("arr")
 	assert.True(t, ok)
-	assert.Equal(t, []string{"a", "b"}, inner0)
-	inner1, ok := outer[1].([]string)
-	assert.True(t, ok)
-	assert.Equal(t, []string{"c"}, inner1)
+	arr, ok := v.([]any)
+	assert.True(t, ok, "expected []any, got %T", v)
+	assert.Empty(t, arr)
+}
+
+func TestToStringSlice(t *testing.T) {
+	t.Parallel()
+
+	ss, err := ToStringSlice(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{}, ss)
+
+	ss, err = ToStringSlice([]any{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{}, ss)
+
+	ss, err = ToStringSlice([]any{"a", "b"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, ss)
+
+	// Already-typed []string (e.g. set programmatically via Set) is accepted as-is.
+	ss, err = ToStringSlice([]string{"a", "b"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, ss)
+
+	_, err = ToStringSlice("not a slice")
+	assert.ErrorContains(t, err, `expected []any or []string, found "string"`)
+
+	_, err = ToStringSlice([]any{"a", 1})
+	assert.ErrorContains(t, err, `expected string at index 1, found "int"`)
 }

--- a/pkg/orderedmap/orderedmap.go
+++ b/pkg/orderedmap/orderedmap.go
@@ -389,33 +389,6 @@ func visit(key Path, valueRaw any, parent any, callback VisitCallback) {
 	}
 }
 
-// ToStringSlice converts a value obtained from OrderedMap (e.g. via Get or GetNested) into a
-// []string. OrderedMap itself never guesses a field's schema from its runtime content - JSON/YAML
-// arrays always decode to []any - so callers that know a specific field is a string array must
-// opt in explicitly via this helper. Accepts either []any (the JSON/YAML-decoded shape) or
-// []string directly (e.g. a value set programmatically via Set). A nil value converts to an
-// empty, non-nil []string.
-func ToStringSlice(value any) ([]string, error) {
-	switch v := value.(type) {
-	case nil:
-		return []string{}, nil
-	case []string:
-		return v, nil
-	case []any:
-		out := make([]string, len(v))
-		for i, item := range v {
-			s, ok := item.(string)
-			if !ok {
-				return nil, fmt.Errorf(`expected string at index %d, found "%T"`, i, item)
-			}
-			out[i] = s
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf(`expected []any or []string, found "%T"`, value)
-	}
-}
-
 func convertToMap(value any) any {
 	switch v := value.(type) {
 	case *OrderedMap:

--- a/pkg/orderedmap/orderedmap.go
+++ b/pkg/orderedmap/orderedmap.go
@@ -389,6 +389,33 @@ func visit(key Path, valueRaw any, parent any, callback VisitCallback) {
 	}
 }
 
+// ToStringSlice converts a value obtained from OrderedMap (e.g. via Get or GetNested) into a
+// []string. OrderedMap itself never guesses a field's schema from its runtime content - JSON/YAML
+// arrays always decode to []any - so callers that know a specific field is a string array must
+// opt in explicitly via this helper. Accepts either []any (the JSON/YAML-decoded shape) or
+// []string directly (e.g. a value set programmatically via Set). A nil value converts to an
+// empty, non-nil []string.
+func ToStringSlice(value any) ([]string, error) {
+	switch v := value.(type) {
+	case nil:
+		return []string{}, nil
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf(`expected string at index %d, found "%T"`, i, item)
+			}
+			out[i] = s
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf(`expected []any or []string, found "%T"`, value)
+	}
+}
+
 func convertToMap(value any) any {
 	switch v := value.(type) {
 	case *OrderedMap:


### PR DESCRIPTION
Jira: https://linear.app/keboola/issue/PSGO-37/investigate-keboolago-utils-change

**Changes:**
- `pkg/orderedmap/json.go`: delete `convertStringSliceIfPossible`/`convertNestedSlices` and their 2 call sites in the decoder. Arrays now always decode to `[]any`, matching `encoding/json`'s stdlib behavior for `map[string]interface{}` (this is what `OrderedMap` did before v1.4.1/PR #60).
- `pkg/orderedmap/orderedmap.go`: add an exported, opt-in `ToStringSlice(value any) ([]string, error)` helper for callers that know a specific field's schema is a string array.
- `pkg/orderedmap/json_test.go`: rewrite the 2 tests that encoded the old coercion as a requirement; add a regression test for the empty-array case and a table test for `ToStringSlice`.

**Why:** v1.4.1 (PR #60) made the JSON decoder silently retype *any* array to `[]string` whenever every element happened to be a string at runtime - including every empty array, unconditionally, regardless of the field's true schema. That's value-dependent type coercion, not schema-based, and it broke every existing `.([]any)` assertion in downstream consumers wherever a field is always-string content or sometimes empty - concretely in keboola-as-code: orchestrator `dependsOn` (phase links silently dropped), `shared_code_row_ids` (every shared-code-linking transformation errors), JSON-Schema `required`/`allOf`/enum processing (silent no-ops), default-bucket rewriting and transformation block loading (skipped on empty arrays). Two attempts to adopt v1.4.1 in keboola-as-code were reverted same-day because of this (`eacc44026`, `bd8a26178`).

A prior attempt at a fix (#68) went in this same direction - disabling the coercion - but left the functions commented out rather than removed, and was never merged. This PR completes that direction properly: clean removal, explicit opt-in replacement, and tests that guard the specific regressions found (empty array, all-string array).

The field name used in the test (`rowsSortOrder`) is the one referenced by the originating bug report, but `Config.RowsSortOrder` in keboola-sdk-go is actually a plain typed `[]string` struct field decoded directly by jsoniter's reflection decoder - it never passes through `OrderedMap` at all. So this global coercion could not have fixed its own stated motivation even in principle. The real call site that needs `ToStringSlice` is being identified in the keboola-as-code adoption PR (follow-up).

Deliberately split from the pure Go-version bump (PSGO-38, #71) so the two can be reviewed and rolled back independently.

Verified: `go build ./...`, `go vet ./...`, `task tests` (64 tests, 1 pre-existing unrelated skip), `golangci-lint run` with the CI-pinned v2.0.2 binary - all clean.

-----------